### PR TITLE
Handle negative divisors in modulo helper

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { modulo } from './math';
+
+describe('modulo', () => {
+    it('handles negative dividend', () => {
+        expect(modulo(-1.5, 1)).toBeCloseTo(0.5);
+    });
+    it('handles negative divisor', () => {
+        expect(modulo(5, -2)).toBe(1);
+    });
+});

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,0 +1,6 @@
+export function modulo(n: number, m: number): number {
+    if (m === 0) return NaN;
+    const mod = Math.abs(m);
+    // handle negative numbers and divisors
+    return ((n % mod) + mod) % mod;
+}

--- a/src/routes/Counter.svelte
+++ b/src/routes/Counter.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-	import { Spring } from 'svelte/motion';
+        import { Spring } from 'svelte/motion';
+        import { modulo } from '$lib/math';
 
-	const count = new Spring(0);
-	const offset = $derived(modulo(count.current, 1));
-
-	function modulo(n: number, m: number) {
-		// handle negative numbers
-		return ((n % m) + m) % m;
-	}
+        const count = new Spring(0);
+        const offset = $derived(modulo(count.current, 1));
 </script>
 
 <div class="counter">


### PR DESCRIPTION
## Summary
- Extract common `modulo` helper and handle negative divisors safely
- Use new helper in `Counter` component
- Cover helper with tests for negative dividend and divisor

## Testing
- `npx playwright install` *(fails: Download failed: server returned code 403)*
- `npm run check`
- `npm test -- --project server`


------
https://chatgpt.com/codex/tasks/task_e_68ad157e9cfc832bb2c33a157bb437d0