### PR TITLE
Improve documentation styling for better readability

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,40 +3,82 @@
 @plugin '@tailwindcss/typography';
 
 :root {
-	--font-body:
-		Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-		'Open Sans', 'Helvetica Neue', sans-serif;
-	--font-mono: 'Fira Mono', monospace;
-	--color-bg-0: rgb(202, 216, 228);
-	--color-bg-1: hsl(209, 36%, 86%);
-	--color-bg-2: hsl(224, 44%, 95%);
-	--color-theme-1: #ff3e00;
-	--color-theme-2: #4075a6;
-	--color-text: rgba(0, 0, 0, 0.7);
-	--column-width: 42rem;
-	--column-margin-top: 4rem;
-	font-family: var(--font-body);
-	color: var(--color-text);
+        --font-body:
+                Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+                'Open Sans', 'Helvetica Neue', sans-serif;
+        --font-mono: 'Fira Mono', monospace;
+        --color-bg-0: rgb(202, 216, 228);
+        --color-bg-1: hsl(209, 36%, 86%);
+        --color-bg-2: hsl(224, 44%, 95%);
+        --color-theme-1: #ff3e00;
+        --color-theme-2: #4075a6;
+        --color-text: rgba(15, 23, 42, 0.84);
+        --text-muted: rgba(71, 85, 105, 0.9);
+        --surface-raised: rgba(255, 255, 255, 0.85);
+        --surface-muted: rgba(255, 255, 255, 0.72);
+        --surface-soft: rgba(255, 255, 255, 0.64);
+        --surface-border: rgba(15, 23, 42, 0.08);
+        --surface-border-strong: rgba(15, 23, 42, 0.16);
+        --accent-warm-bg: rgba(255, 179, 71, 0.16);
+        --accent-warm-border: rgba(255, 179, 71, 0.35);
+        --accent-info-bg: rgba(59, 130, 246, 0.12);
+        --accent-info-border: rgba(59, 130, 246, 0.26);
+        --accent-danger-bg: rgba(254, 226, 226, 0.72);
+        --accent-danger-border: rgba(239, 68, 68, 0.35);
+        --accent-danger-text: #b91c1c;
+        --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.08);
+        --shadow-medium: 0 25px 55px rgba(15, 23, 42, 0.12);
+        --code-inline-bg: rgba(15, 23, 42, 0.08);
+        --code-inline-text: rgba(15, 23, 42, 0.96);
+        --code-block-bg: rgba(15, 23, 42, 0.94);
+        --code-block-text: rgba(248, 250, 252, 0.98);
+        --code-border: rgba(100, 116, 139, 0.2);
+        --tag-text-on-accent: #0b1120;
+        --column-width: 42rem;
+        --column-margin-top: 4rem;
+        font-family: var(--font-body);
+        color: var(--color-text);
 }
 
 [data-theme='dark'] {
-	--color-bg-0: rgb(32, 32, 40);
-	--color-bg-1: hsl(220, 14%, 16%);
-	--color-bg-2: hsl(220, 14%, 12%);
-	--color-theme-1: #ff6b35;
-	--color-theme-2: #7dd3fc;
-	--color-text: rgba(255, 255, 255, 0.87);
+        --color-bg-0: rgb(32, 32, 40);
+        --color-bg-1: hsl(220, 14%, 16%);
+        --color-bg-2: hsl(220, 14%, 12%);
+        --color-theme-1: #ff6b35;
+        --color-theme-2: #7dd3fc;
+        --color-text: rgba(241, 245, 249, 0.92);
+        --text-muted: rgba(203, 213, 225, 0.7);
+        --surface-raised: rgba(15, 23, 42, 0.78);
+        --surface-muted: rgba(22, 30, 49, 0.82);
+        --surface-soft: rgba(30, 41, 59, 0.76);
+        --surface-border: rgba(148, 163, 184, 0.22);
+        --surface-border-strong: rgba(148, 163, 184, 0.32);
+        --accent-warm-bg: rgba(255, 179, 71, 0.22);
+        --accent-warm-border: rgba(255, 196, 120, 0.45);
+        --accent-info-bg: rgba(59, 130, 246, 0.16);
+        --accent-info-border: rgba(125, 211, 252, 0.5);
+        --accent-danger-bg: rgba(127, 29, 29, 0.6);
+        --accent-danger-border: rgba(248, 113, 113, 0.42);
+        --accent-danger-text: rgba(252, 165, 165, 0.92);
+        --shadow-soft: 0 30px 60px rgba(2, 6, 23, 0.6);
+        --shadow-medium: 0 45px 70px rgba(2, 6, 23, 0.7);
+        --code-inline-bg: rgba(148, 163, 184, 0.16);
+        --code-inline-text: rgba(226, 232, 240, 0.92);
+        --code-block-bg: rgba(10, 15, 28, 0.88);
+        --code-block-text: rgba(236, 242, 255, 0.96);
+        --code-border: rgba(148, 163, 184, 0.35);
+        --tag-text-on-accent: #082f49;
 }
 
 body {
-	min-height: 100vh;
-	margin: 0;
-	background-attachment: fixed;
-	background-color: var(--color-bg-1);
-	background-size: 100vw 100vh;
-	background-image:
-		radial-gradient(50% 50% at 50% 50%, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0) 100%),
-		linear-gradient(180deg, var(--color-bg-0) 0%, var(--color-bg-1) 15%, var(--color-bg-2) 50%);
+        min-height: 100vh;
+        margin: 0;
+        background-attachment: fixed;
+        background-color: var(--color-bg-1);
+        background-size: 100vw 100vh;
+        background-image:
+                radial-gradient(50% 50% at 50% 50%, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0) 100%),
+                linear-gradient(180deg, var(--color-bg-0) 0%, var(--color-bg-1) 15%, var(--color-bg-2) 50%);
 }
 
 h1,
@@ -46,36 +88,46 @@ p {
 }
 
 p {
-	line-height: 1.5;
+        line-height: 1.6;
 }
 
 a {
-	color: var(--color-theme-1);
-	text-decoration: none;
+        color: var(--color-theme-1);
+        text-decoration: none;
+        transition: color 0.2s ease;
 }
 
-a:hover {
-	text-decoration: underline;
+a:hover,
+a:focus-visible {
+        text-decoration: underline;
+        color: var(--color-theme-2);
 }
 
 h1 {
-	font-size: 2rem;
-	text-align: center;
+        font-size: 2rem;
+        text-align: center;
 }
 
 h2 {
-	font-size: 1rem;
+        font-size: 1rem;
 }
 
 pre {
-	font-size: 16px;
-	font-family: var(--font-mono);
-	background-color: rgba(255, 255, 255, 0.45);
-	border-radius: 3px;
-	box-shadow: 2px 2px 6px rgb(255 255 255 / 25%);
-	padding: 0.5em;
-	overflow-x: auto;
-	color: var(--color-text);
+        font-size: 0.95rem;
+        font-family: var(--font-mono);
+        background-color: var(--code-block-bg);
+        color: var(--code-block-text);
+        border-radius: 0.75rem;
+        border: 1px solid var(--code-border);
+        box-shadow: var(--shadow-soft);
+        padding: 1.125rem 1.25rem;
+        overflow-x: auto;
+}
+
+pre code {
+        background: transparent;
+        color: inherit;
+        font-size: inherit;
 }
 
 .text-column {
@@ -89,8 +141,8 @@ pre {
 
 input,
 button {
-	font-size: inherit;
-	font-family: inherit;
+        font-size: inherit;
+        font-family: inherit;
 }
 
 button:focus:not(:focus-visible) {
@@ -104,13 +156,23 @@ button:focus:not(:focus-visible) {
 }
 
 .visually-hidden {
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: auto;
-	margin: 0;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px;
-	white-space: nowrap;
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: auto;
+        margin: 0;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
+}
+
+code {
+        background: var(--code-inline-bg);
+        color: var(--code-inline-text);
+        padding: 0.125rem 0.35rem;
+        border-radius: 0.35rem;
+        font-family: var(--font-mono);
+        font-size: 0.9em;
+        border: 1px solid var(--code-border);
 }

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -437,324 +437,406 @@
 </div>
 
 <style>
-	.docs-container {
-		display: grid;
-		grid-template-columns: 250px 1fr;
-		min-height: 100vh;
-		gap: 2rem;
-		max-width: 1400px;
-		margin: 0 auto;
-		padding: 2rem;
-	}
+        .docs-container {
+                display: grid;
+                grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+                gap: clamp(1.5rem, 4vw, 3rem);
+                width: 100%;
+                max-width: min(1200px, 100%);
+                margin: 0 auto;
+                padding: clamp(1.5rem, 4vw, 3rem);
+                align-items: start;
+                box-sizing: border-box;
+        }
 
-	.docs-nav {
-		position: sticky;
-		top: 2rem;
-		height: fit-content;
-		background: var(--color-bg-1);
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		border: 1px solid rgba(255, 255, 255, 0.1);
-	}
+        .docs-nav {
+                position: sticky;
+                top: clamp(1rem, 2vw, 2.5rem);
+                height: fit-content;
+                background: var(--surface-raised);
+                padding: 1.75rem;
+                border-radius: 1rem;
+                border: 1px solid var(--surface-border);
+                box-shadow: var(--shadow-soft);
+                backdrop-filter: blur(12px);
+                -webkit-backdrop-filter: blur(12px);
+        }
 
-	.back-link {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		color: #6b7280;
-		text-decoration: none;
-		margin-bottom: 1rem;
-		font-size: 0.875rem;
-	}
+        .docs-nav h1 {
+                margin-bottom: 1.5rem;
+        }
 
-	.back-link:hover {
-		color: #374151;
-	}
+        .back-link {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                color: var(--text-muted);
+                text-decoration: none;
+                margin-bottom: 1rem;
+                font-size: 0.9rem;
+                font-weight: 500;
+                transition: color 0.2s ease, transform 0.2s ease;
+        }
 
-	.nav-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
+        .back-link:hover,
+        .back-link:focus-visible {
+                color: var(--color-theme-1);
+                transform: translateX(-4px);
+        }
 
-	.nav-list li {
-		margin-bottom: 0.5rem;
-	}
+        .nav-list {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+                display: flex;
+                flex-direction: column;
+                gap: 0.35rem;
+        }
 
-	.nav-list a {
-		color: #6b7280;
-		text-decoration: none;
-		padding: 0.25rem 0;
-		display: block;
-		border-radius: 0.25rem;
-		transition: color 0.2s;
-	}
+        .nav-list a {
+                color: var(--text-muted);
+                text-decoration: none;
+                padding: 0.35rem 0.6rem;
+                border-radius: 0.5rem;
+                transition: color 0.2s ease, background-color 0.2s ease;
+                font-weight: 500;
+        }
 
-	.nav-list a:hover {
-		color: #3b82f6;
-	}
+        .nav-list a:hover,
+        .nav-list a:focus-visible {
+                color: var(--color-theme-1);
+                background: var(--surface-muted);
+        }
 
-	.docs-content {
-		max-width: none;
-	}
+        .docs-content {
+                min-width: 0;
+                display: flex;
+                flex-direction: column;
+                gap: 3rem;
+        }
 
-	.section {
-		margin-bottom: 3rem;
-		padding-bottom: 2rem;
-		border-bottom: 1px solid #e5e7eb;
-	}
+        .section {
+                display: flex;
+                flex-direction: column;
+                gap: 1.25rem;
+                padding-bottom: 2.5rem;
+                border-bottom: 1px solid var(--surface-border);
+                scroll-margin-top: 8rem;
+        }
 
-	.section:last-child {
-		border-bottom: none;
-	}
+        .section:last-child {
+                border-bottom: none;
+                padding-bottom: 0;
+        }
 
-	.feature-comparison {
-		background: var(--color-bg-1);
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		border: 1px solid rgba(255, 255, 255, 0.1);
-	}
+        .section h2 {
+                font-size: clamp(1.75rem, 2vw, 2.25rem);
+                font-weight: 700;
+        }
 
-	.comparison-card {
-		background: var(--color-bg-2);
-		padding: 1.5rem;
-		border-radius: 0.5rem;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-		border: 1px solid rgba(255, 255, 255, 0.1);
-	}
+        .section h3 {
+                font-size: clamp(1.1rem, 1.5vw, 1.35rem);
+                font-weight: 600;
+        }
 
-	.installation-methods {
-		display: grid;
-		gap: 1.5rem;
-	}
+        .section h4 {
+                font-size: 1rem;
+                font-weight: 600;
+                color: var(--text-muted);
+        }
 
-	.method-card {
-		background: var(--color-bg-1);
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		border: 1px solid rgba(255, 255, 255, 0.1);
-	}
+        .feature-comparison {
+                background: var(--surface-raised);
+                padding: 1.75rem;
+                border-radius: 1rem;
+                border: 1px solid var(--surface-border);
+                box-shadow: var(--shadow-soft);
+        }
 
-	.addon-code {
-		background: #3b82f6;
-		color: white;
-		padding: 0.25rem 0.5rem;
-		border-radius: 0.25rem;
-		font-weight: 600;
-	}
+        .comparison-card {
+                background: var(--surface-muted);
+                padding: 1.5rem;
+                border-radius: 0.85rem;
+                border: 1px solid var(--surface-border);
+                box-shadow: var(--shadow-soft);
+                transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
 
-	.note {
-		background: #fef3c7;
-		border: 1px solid #f59e0b;
-		padding: 1rem;
-		border-radius: 0.5rem;
-		margin-top: 1rem;
-	}
+        .comparison-card:hover {
+                transform: translateY(-4px);
+                box-shadow: var(--shadow-medium);
+        }
 
-	.config-section {
-		margin-bottom: 2rem;
-	}
+        .installation-methods {
+                display: grid;
+                gap: 1.5rem;
+        }
 
-	.config-example,
-	.config-code {
-		background: #1f2937;
-		color: #f9fafb;
-		padding: 1rem;
-		border-radius: 0.5rem;
-		overflow-x: auto;
-		font-family: 'Courier New', monospace;
-		font-size: 0.875rem;
-	}
+        .method-card {
+                background: var(--surface-raised);
+                border: 1px solid var(--surface-border);
+                border-radius: 1rem;
+                padding: 1.5rem;
+                box-shadow: var(--shadow-soft);
+        }
 
-	.host-configs {
-		display: grid;
-		gap: 1rem;
-	}
+        .addon-code {
+                background: var(--color-theme-2);
+                color: var(--tag-text-on-accent);
+                padding: 0.25rem 0.6rem;
+                border-radius: 0.4rem;
+                font-weight: 600;
+                letter-spacing: 0.02em;
+        }
 
-	.host-config {
-		background: #f9fafb;
-		padding: 1rem;
-		border-radius: 0.5rem;
-		border: 1px solid #e5e7eb;
-	}
+        .note {
+                background: var(--accent-warm-bg);
+                border: 1px solid var(--accent-warm-border);
+                padding: 1rem;
+                border-radius: 0.75rem;
+        }
 
-	.capabilities-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-		gap: 1.5rem;
-	}
+        .config-section {
+                display: flex;
+                flex-direction: column;
+                gap: 1rem;
+        }
 
-	.capability-card {
-		background: white;
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-		border: 1px solid #e5e7eb;
-	}
+        .config-example,
+        .config-code {
+                background: var(--code-block-bg);
+                color: var(--code-block-text);
+                border: 1px solid var(--code-border);
+                border-radius: 0.85rem;
+                padding: 1.25rem;
+                box-shadow: var(--shadow-soft);
+                overflow-x: auto;
+                font-family: var(--font-mono);
+                font-size: 0.95rem;
+        }
 
-	.capability-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
+        .config-code code {
+                background: transparent;
+                color: inherit;
+                padding: 0;
+                border: 0;
+        }
 
-	.capability-list li {
-		padding: 0.5rem 0;
-		border-bottom: 1px solid #f3f4f6;
-		font-size: 0.875rem;
-	}
+        .host-configs {
+                display: grid;
+                gap: 1.25rem;
+        }
 
-	.capability-list li:last-child {
-		border-bottom: none;
-	}
+        .host-config {
+                background: var(--surface-raised);
+                border: 1px solid var(--surface-border);
+                border-radius: 1rem;
+                padding: 1.5rem;
+                box-shadow: var(--shadow-soft);
+        }
 
-	.capability-list code {
-		background: #e5e7eb;
-		padding: 0.125rem 0.375rem;
-		border-radius: 0.25rem;
-		font-size: 0.75rem;
-		font-weight: 600;
-	}
+        .capabilities-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+                gap: 1.5rem;
+        }
 
-	.api-reference {
-		display: grid;
-		gap: 2rem;
-	}
+        .capability-card {
+                background: var(--surface-raised);
+                border: 1px solid var(--surface-border);
+                border-radius: 1rem;
+                padding: 1.5rem;
+                box-shadow: var(--shadow-soft);
+                transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
 
-	.api-method {
-		background: #f9fafb;
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		border: 1px solid #e5e7eb;
-	}
+        .capability-card:hover {
+                transform: translateY(-4px);
+                box-shadow: var(--shadow-medium);
+        }
 
-	.api-method-name {
-		font-family: 'Courier New', monospace;
-		font-size: 1.25rem;
-		font-weight: bold;
-		color: #3b82f6;
-		margin-bottom: 0.5rem;
-	}
+        .capability-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+        }
 
-	.api-description {
-		color: #6b7280;
-		margin-bottom: 1rem;
-	}
+        .capability-list li {
+                padding: 0.6rem 0;
+                border-bottom: 1px solid var(--surface-border);
+                font-size: 0.95rem;
+        }
 
-	.api-parameters h4,
-	.api-example h4 {
-		font-weight: 600;
-		margin-bottom: 0.5rem;
-		font-size: 0.875rem;
-	}
+        .capability-list li:last-child {
+                border-bottom: none;
+        }
 
-	.api-parameters ul {
-		list-style: none;
-		padding: 0;
-		margin-bottom: 1rem;
-	}
+        .capability-list code {
+                font-size: 0.85rem;
+                font-weight: 600;
+        }
 
-	.api-parameters li {
-		padding: 0.25rem 0;
-		font-size: 0.875rem;
-	}
+        .api-reference {
+                display: grid;
+                gap: 1.5rem;
+        }
 
-	.api-code {
-		background: #1f2937;
-		color: #f9fafb;
-		padding: 1rem;
-		border-radius: 0.5rem;
-		overflow-x: auto;
-		font-family: 'Courier New', monospace;
-		font-size: 0.75rem;
-	}
+        .api-method {
+                background: var(--surface-raised);
+                border: 1px solid var(--surface-border);
+                border-radius: 1rem;
+                padding: 1.5rem;
+                box-shadow: var(--shadow-soft);
+                display: flex;
+                flex-direction: column;
+                gap: 1rem;
+        }
 
-	.security-features {
-		display: grid;
-		gap: 1.5rem;
-	}
+        .api-method-name {
+                font-size: 1.15rem;
+                font-weight: 600;
+        }
 
-	.security-feature {
-		background: #f9fafb;
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		border: 1px solid #e5e7eb;
-	}
+        .api-description {
+                color: var(--text-muted);
+                margin-bottom: 1rem;
+        }
 
-	.security-code {
-		background: #1f2937;
-		color: #f9fafb;
-		padding: 1rem;
-		border-radius: 0.5rem;
-		font-family: 'Courier New', monospace;
-		font-size: 0.75rem;
-		margin: 0.5rem 0;
-	}
+        .api-parameters h4,
+        .api-example h4 {
+                font-weight: 600;
+                margin-bottom: 0.5rem;
+                font-size: 0.95rem;
+                color: var(--text-muted);
+        }
 
-	.troubleshooting-guide {
-		display: grid;
-		gap: 1.5rem;
-	}
+        .api-parameters ul {
+                list-style: none;
+                padding: 0;
+                margin: 0 0 1rem;
+        }
 
-	.issue {
-		background: #fef2f2;
-		border: 1px solid #fecaca;
-		border-radius: 0.75rem;
-		overflow: hidden;
-	}
+        .api-parameters li {
+                padding: 0.35rem 0;
+                font-size: 0.95rem;
+        }
 
-	.issue-title {
-		background: #fee2e2;
-		padding: 1rem 1.5rem;
-		margin: 0;
-		font-size: 1.125rem;
-		font-weight: 600;
-		color: #dc2626;
-	}
+        .api-code {
+                background: var(--code-block-bg);
+                color: var(--code-block-text);
+                border: 1px solid var(--code-border);
+                border-radius: 0.85rem;
+                padding: 1.25rem;
+                font-family: var(--font-mono);
+                font-size: 0.9rem;
+                box-shadow: var(--shadow-soft);
+        }
 
-	.issue-content {
-		padding: 1.5rem;
-	}
+        .security-features,
+        .troubleshooting-guide {
+                display: grid;
+                gap: 1.5rem;
+        }
 
-	.help-section {
-		background: #eff6ff;
-		border: 1px solid #bfdbfe;
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		margin-top: 1.5rem;
-	}
+        .security-feature {
+                background: var(--surface-raised);
+                border: 1px solid var(--surface-border);
+                border-radius: 1rem;
+                padding: 1.5rem 1.5rem 1.5rem 1.75rem;
+                box-shadow: var(--shadow-soft);
+                border-left: 4px solid var(--color-theme-2);
+        }
 
-	.link {
-		color: #3b82f6;
-		text-decoration: none;
-	}
+        .security-code {
+                background: var(--code-block-bg);
+                color: var(--code-block-text);
+                border: 1px solid var(--code-border);
+                border-radius: 0.85rem;
+                padding: 1.1rem;
+                font-family: var(--font-mono);
+                font-size: 0.9rem;
+                box-shadow: var(--shadow-soft);
+        }
 
-	.link:hover {
-		text-decoration: underline;
-	}
+        .issue {
+                background: var(--accent-danger-bg);
+                border: 1px solid var(--accent-danger-border);
+                border-radius: 1rem;
+                overflow: hidden;
+                box-shadow: var(--shadow-soft);
+        }
 
-	code {
-		background: #e5e7eb;
-		padding: 0.125rem 0.375rem;
-		border-radius: 0.25rem;
-		font-family: 'Courier New', monospace;
-		font-size: 0.875em;
-	}
+        .issue-title {
+                padding: 1rem 1.5rem 0.75rem;
+                margin: 0;
+                font-size: 1.1rem;
+                font-weight: 600;
+                color: var(--accent-danger-text);
+                border-bottom: 1px solid var(--accent-danger-border);
+        }
 
-	@media (max-width: 768px) {
-		.docs-container {
-			grid-template-columns: 1fr;
-			gap: 1rem;
-			padding: 1rem;
-		}
+        .issue-content {
+                padding: 1.25rem 1.5rem 1.5rem;
+        }
 
-		.docs-nav {
-			position: relative;
-			top: auto;
-		}
+        .help-section {
+                background: var(--accent-info-bg);
+                border: 1px solid var(--accent-info-border);
+                border-radius: 1rem;
+                padding: 1.5rem;
+                box-shadow: var(--shadow-soft);
+        }
 
-		.capabilities-grid {
-			grid-template-columns: 1fr;
-		}
-	}
+        .link {
+                color: var(--color-theme-2);
+        }
+
+        .link:hover,
+        .link:focus-visible {
+                color: var(--color-theme-1);
+        }
+
+        .config-example code,
+        .api-code code,
+        .security-code code {
+                background: transparent;
+                color: inherit;
+                padding: 0;
+                border: 0;
+        }
+
+        @media (max-width: 1024px) {
+                .docs-container {
+                        grid-template-columns: 1fr;
+                        padding: clamp(1.25rem, 5vw, 2rem);
+                }
+
+                .docs-nav {
+                        position: relative;
+                        top: auto;
+                        display: grid;
+                        gap: 1rem;
+                }
+
+                .docs-content {
+                        gap: 2.5rem;
+                }
+        }
+
+        @media (max-width: 640px) {
+                .feature-comparison,
+                .method-card,
+                .config-example,
+                .config-code,
+                .api-method,
+                .security-feature,
+                .issue,
+                .help-section {
+                        padding: 1.25rem;
+                }
+
+                .api-method {
+                        gap: 0.75rem;
+                }
+        }
 </style>

--- a/src/types/lucide-svelte.d.ts
+++ b/src/types/lucide-svelte.d.ts
@@ -1,0 +1,1 @@
+declare module 'lucide-svelte';


### PR DESCRIPTION
## Summary
- introduce theme-aware surface variables and refined code styling for consistent light and dark modes
- refresh the documentation layout with responsive cards, readable code blocks, and better navigation spacing
- declare the lucide-svelte module to keep type checking green

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ffa16fb894832ba82c368135414bc5